### PR TITLE
fix: escape ACF values in Style Guide shortcode output

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -78,7 +78,7 @@ function bb_a_z_style_guide_single_loop(){
 	if( have_rows('style_definitions') ):while( have_rows('style_definitions') ): the_row();
 		$azItem = get_sub_field('editorial_style_item');
 		$azDef = get_sub_field('editorial_style_definition');		
-		$finaldefs .= '<p><b>'.$azItem.':</b></p>'.$azDef.'<hr>';
+		$finaldefs .= '<p><b>' . esc_html( $azItem ) . ':</b></p>' . wp_kses_post( $azDef ) . '<hr>';
 		endwhile;
 	endif;
 
@@ -118,7 +118,7 @@ function bb_a_z_styles_archive_loop() {
 					// vars
 					$azItem = get_sub_field('editorial_style_item');
 					$azDef = get_sub_field('editorial_style_definition');
-					$finalloop .= '<p><b>'.$azItem.':</b></p>'.$azDef.'<hr>';
+					$finalloop .= '<p><b>' . esc_html( $azItem ) . ':</b></p>' . wp_kses_post( $azDef ) . '<hr>';
 				endwhile;
 			endif;
 		endwhile;

--- a/tests/ShortcodeEscapingTest.php
+++ b/tests/ShortcodeEscapingTest.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * BB-01 — shortcode output must escape ACF values.
+ *
+ * @package Blackbird_Sandbox
+ */
+
+/**
+ * Escaping regressions for [style-definition] and [style-archive].
+ */
+class ShortcodeEscapingTest extends Blackbird_TestCase {
+
+	/**
+	 * A script payload an editor could save into the text sub-field.
+	 */
+	const PAYLOAD = '<script>alert("xss")</script>';
+
+	/**
+	 * The item name is an ACF text field and must be escaped outright.
+	 */
+	public function test_style_definition_escapes_item_name() {
+		Blackbird_ACF_Stub::set_rows(
+			array(
+				array(
+					'editorial_style_item'       => self::PAYLOAD,
+					'editorial_style_definition' => '<p>A definition.</p>',
+				),
+			)
+		);
+
+		$output = do_shortcode( '[style-definition]' );
+
+		$this->assertStringNotContainsString( '<script>', $output, 'Raw <script> reached the output.' );
+		$this->assertStringContainsString( '&lt;script&gt;', $output, 'Payload was not HTML-escaped.' );
+	}
+
+	/**
+	 * The definition is an ACF wysiwyg field.
+	 *
+	 * It must keep safe markup — escaping it outright would render every
+	 * definition as visible tag soup — while still losing script tags.
+	 */
+	public function test_style_definition_filters_wysiwyg_but_keeps_markup() {
+		Blackbird_ACF_Stub::set_rows(
+			array(
+				array(
+					'editorial_style_item'       => 'Oxford comma',
+					'editorial_style_definition' => '<p>Use <strong>always</strong>. <a href="https://example.com">Ref</a>.</p>'
+						. '<script>alert("xss")</script>',
+				),
+			)
+		);
+
+		$output = do_shortcode( '[style-definition]' );
+
+		$this->assertStringNotContainsString( '<script>', $output, 'Script survived wp_kses_post().' );
+		$this->assertStringContainsString( '<strong>always</strong>', $output, 'Legitimate markup was stripped.' );
+		$this->assertStringContainsString( 'href="https://example.com"', $output, 'Links were stripped.' );
+	}
+
+	/**
+	 * The archive shortcode has the same defect at its own call site.
+	 */
+	public function test_style_archive_escapes_item_name() {
+		self::factory()->post->create(
+			array(
+				'post_type'   => self::POST_TYPE,
+				'post_title'  => 'Entry',
+				'post_status' => 'publish',
+			)
+		);
+
+		Blackbird_ACF_Stub::set_rows(
+			array(
+				array(
+					'editorial_style_item'       => self::PAYLOAD,
+					'editorial_style_definition' => '<p>A definition.</p>',
+				),
+			)
+		);
+
+		$output = do_shortcode( '[style-archive]' );
+
+		$this->assertStringNotContainsString( '<script>', $output, 'Raw <script> reached the archive output.' );
+		$this->assertStringContainsString( '&lt;script&gt;', $output, 'Payload was not HTML-escaped in the archive.' );
+	}
+}

--- a/tests/Support/BlackbirdTestCase.php
+++ b/tests/Support/BlackbirdTestCase.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Shared base for tests that exercise the Style Guide shortcodes.
+ *
+ * @package Blackbird_Sandbox
+ */
+
+/**
+ * Registers the post type the plugin assumes and resets the ACF stub.
+ */
+abstract class Blackbird_TestCase extends WP_UnitTestCase {
+
+	/**
+	 * Post type the plugin queries.
+	 *
+	 * Normally registered by ACF from acf-json/post_type_685d7e97c87c6.json.
+	 * ACF is absent here, so the tests register it themselves.
+	 */
+	const POST_TYPE = 'a_z_style_guide';
+
+	/**
+	 * Register the post type and clear stub state.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		register_post_type(
+			self::POST_TYPE,
+			array(
+				'public'      => true,
+				'has_archive' => true,
+				'label'       => 'A-Z Style Guide',
+			)
+		);
+
+		Blackbird_ACF_Stub::reset();
+	}
+
+	/**
+	 * Unregister and clear.
+	 */
+	public function tear_down() {
+		unregister_post_type( self::POST_TYPE );
+		Blackbird_ACF_Stub::reset();
+
+		parent::tear_down();
+	}
+}

--- a/tests/Support/acf-stub.php
+++ b/tests/Support/acf-stub.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Minimal stand-in for the ACF repeater row API.
+ *
+ * ACF is not installed in the test environment and cannot be: the
+ * `style_definitions` field is a Repeater, which is an ACF PRO feature and is
+ * not downloadable from wordpress.org.
+ *
+ * Stubbing is the right boundary regardless. These tests are about what the
+ * plugin does with the values ACF hands back — escaping them, and cleaning up
+ * after the loop — not about ACF's own correctness. Feeding the values
+ * directly is more precise than round-tripping them through a real repeater.
+ *
+ * Guarded by function_exists() so a real ACF install always wins.
+ *
+ * @package Blackbird_Sandbox
+ */
+
+/**
+ * Holds the rows the stubbed loop walks.
+ */
+class Blackbird_ACF_Stub {
+
+	/**
+	 * Rows to serve, each a map of sub-field name => value.
+	 *
+	 * @var array
+	 */
+	public static $rows = array();
+
+	/**
+	 * Cursor into $rows. -1 means the loop has not started.
+	 *
+	 * @var int
+	 */
+	public static $index = -1;
+
+	/**
+	 * Load rows and rewind.
+	 *
+	 * @param array $rows Rows to serve.
+	 */
+	public static function set_rows( array $rows ) {
+		self::$rows  = $rows;
+		self::$index = -1;
+	}
+
+	/**
+	 * Clear all state. Call between tests.
+	 */
+	public static function reset() {
+		self::$rows  = array();
+		self::$index = -1;
+	}
+}
+
+if ( ! function_exists( 'have_rows' ) ) {
+	/**
+	 * Whether a row remains to be consumed.
+	 *
+	 * @param string $selector Field name. Ignored; the stub serves one set.
+	 * @return bool
+	 */
+	function have_rows( $selector = '' ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter
+		return ( Blackbird_ACF_Stub::$index + 1 ) < count( Blackbird_ACF_Stub::$rows );
+	}
+}
+
+if ( ! function_exists( 'the_row' ) ) {
+	/**
+	 * Advance to the next row.
+	 */
+	function the_row() {
+		++Blackbird_ACF_Stub::$index;
+	}
+}
+
+if ( ! function_exists( 'get_sub_field' ) ) {
+	/**
+	 * Read a sub-field from the current row.
+	 *
+	 * @param string $selector Sub-field name.
+	 * @return mixed Value, or null when absent.
+	 */
+	function get_sub_field( $selector = '' ) {
+		$row = Blackbird_ACF_Stub::$rows[ Blackbird_ACF_Stub::$index ] ?? array();
+		return $row[ $selector ] ?? null;
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -48,6 +48,10 @@ if ( ! file_exists( $blackbird_tests_dir . '/includes/functions.php' ) ) {
 
 require_once $blackbird_tests_dir . '/includes/functions.php';
 
+// Test support. The ACF stub must be defined before plugin.php runs, since the
+// shortcodes call into the row API as soon as they are invoked.
+require_once __DIR__ . '/Support/acf-stub.php';
+
 /**
  * Load the plugin under test before WordPress finishes booting.
  *
@@ -60,3 +64,6 @@ function blackbird_manually_load_plugin() {
 tests_add_filter( 'muplugins_loaded', 'blackbird_manually_load_plugin' );
 
 require $blackbird_tests_dir . '/includes/bootstrap.php';
+
+// Depends on WP_UnitTestCase, so it loads after the WordPress bootstrap.
+require_once __DIR__ . '/Support/BlackbirdTestCase.php';


### PR DESCRIPTION
Closes #6.

## What changed

- `plugin.php` — `esc_html()` on `$azItem` and `wp_kses_post()` on `$azDef` at
  both call sites (`bb_a_z_style_guide_single_loop()` and
  `bb_a_z_styles_archive_loop()`). Two lines.
- `tests/ShortcodeEscapingTest.php` — 3 regression tests.
- `tests/Support/acf-stub.php` — minimal stand-in for the ACF repeater row API.
- `tests/Support/BlackbirdTestCase.php` — base case registering the
  `a_z_style_guide` post type and resetting stub state.
- `tests/bootstrap.php` — loads the two support files.

## Why

Any editor with `edit_posts` could store markup that then executed for every
visitor of a page carrying either shortcode.

The two fields need different treatment, which is the whole subtlety here:

- `editorial_style_item` is an ACF **text** field. No markup to preserve →
  `esc_html()`.
- `editorial_style_definition` is an ACF **wysiwyg** field. Its markup is the
  point → `wp_kses_post()`. Escaping this one outright would pass a naive "no
  script tag" test while rendering every definition on the site as visible tag
  soup.

The test pins both directions: script must not survive, and a `<strong>` and an
`<a href>` must.

## Why ACF is stubbed, not installed

`style_definitions` is a **Repeater**, an ACF PRO field. It cannot be pulled
from wordpress.org, so CI could never install it. The test environment has no
ACF at all (`wp plugin list` shows only this plugin and `hello`).

The boundary is right regardless — what is under test is how the plugin treats
values ACF hands back, not ACF's own correctness. The stub is guarded with
`function_exists()`, so a real ACF install always wins.

`BlackbirdTestCase` also registers `a_z_style_guide` itself, since that post
type normally comes from `acf-json/post_type_685d7e97c87c6.json`.

## How to test

```bash
npm run env:start
npm run test:php
```

**Verify the tests catch the defect.** Revert `plugin.php` alone and re-run:

```bash
git checkout main -- plugin.php && npm run test:php
```

I did this before writing the fix. All three fail, with output showing the
payload reaching the page verbatim:

```
Failed asserting that '<p><b><script>alert("xss")</script>:</b></p>...'
does not contain "<script>".
```

After the fix: `OK (6 tests, 14 assertions)`.

## Notes for the reviewer

- **This PR carries shared test support** that #7 and #8 also need. Their
  branches are stacked on this one, so review this first — the alternative was
  duplicating `acf-stub.php` across three branches.
- **Escaping changed the concatenation spacing** on the two touched lines to
  match WPCS. Only lines already being modified; no drive-by reformatting, per
  the roadmap's ordering constraint.
- The `$wpdb->prepare()` query is untouched, as the roadmap requires.

## Breaking changes

None for well-formed content. Markup outside `wp_kses_post()`'s allowlist —
`<script>`, `<iframe>`, event handler attributes — will stop rendering in
definition fields. That is the fix, but if any existing definition legitimately
relies on an embed, it will need revisiting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
