### PR TITLE
fix: reset post data before returning from [style-archive]

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -124,9 +124,9 @@ function bb_a_z_styles_archive_loop() {
 		endwhile;
 	endif;
 
-	return $finalloop;
-
 	wp_reset_postdata();
+
+	return $finalloop;
 }
 
 /**

--- a/tests/ArchiveShortcodePostDataTest.php
+++ b/tests/ArchiveShortcodePostDataTest.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * BB-02 — [style-archive] must restore the global $post.
+ *
+ * @package Blackbird_Sandbox
+ */
+
+/**
+ * Post-data leakage regression for the archive shortcode.
+ */
+class ArchiveShortcodePostDataTest extends Blackbird_TestCase {
+
+	/**
+	 * Content rendered after the shortcode must still see its own post.
+	 *
+	 * The shortcode runs a WP_Query loop, which reassigns the global $post on
+	 * every iteration. Without a reset, everything rendered after it on the
+	 * page draws from the last Style Guide entry instead of the page itself.
+	 */
+	public function test_global_post_is_restored_after_shortcode() {
+		$page_id = self::factory()->post->create(
+			array(
+				'post_type'    => 'page',
+				'post_title'   => 'Editorial Style Guide',
+				'post_content' => '[style-archive]',
+				'post_status'  => 'publish',
+			)
+		);
+
+		self::factory()->post->create(
+			array(
+				'post_type'   => self::POST_TYPE,
+				'post_title'  => 'Zebra',
+				'post_status' => 'publish',
+			)
+		);
+
+		$this->go_to( get_permalink( $page_id ) );
+		the_post();
+
+		$this->assertSame( $page_id, $GLOBALS['post']->ID, 'Test setup failed: global $post is not the page.' );
+
+		do_shortcode( '[style-archive]' );
+
+		$this->assertSame(
+			$page_id,
+			$GLOBALS['post']->ID,
+			'Global $post was left pointing at a Style Guide entry; content after the shortcode will render the wrong post.'
+		);
+	}
+
+	/**
+	 * Template tags after the shortcode must reflect the page, not the loop.
+	 *
+	 * States the same defect in the terms an author would notice.
+	 */
+	public function test_the_title_after_shortcode_is_the_page_title() {
+		$page_id = self::factory()->post->create(
+			array(
+				'post_type'   => 'page',
+				'post_title'  => 'Editorial Style Guide',
+				'post_status' => 'publish',
+			)
+		);
+
+		self::factory()->post->create(
+			array(
+				'post_type'   => self::POST_TYPE,
+				'post_title'  => 'Zebra',
+				'post_status' => 'publish',
+			)
+		);
+
+		$this->go_to( get_permalink( $page_id ) );
+		the_post();
+
+		do_shortcode( '[style-archive]' );
+
+		$this->assertSame( 'Editorial Style Guide', get_the_title(), 'get_the_title() returned a Style Guide entry.' );
+	}
+}


### PR DESCRIPTION
Closes #7.

> **Stacked on #21.** Base is `fix/bb-01-escape-shortcode-output`, not `main`,
> because this branch needs the shared test support that PR introduces. Merge
> #21 first; this base retargets to `main` automatically.

## What changed

- `plugin.php` — moved `wp_reset_postdata()` above the `return`. Two lines
  swapped.
- `tests/ArchiveShortcodePostDataTest.php` — 2 regression tests.

## Why

```php
	return $finalloop;

	wp_reset_postdata();   // unreachable
}
```

The call sat after the `return` and never executed. The `WP_Query` loop
reassigns the global `$post` on every iteration, so after the shortcode ran,
`$post` pointed at the last Style Guide entry. Everything rendered after
`[style-archive]` on the same page drew from that post — wrong title, wrong
content, wrong meta.

## How to test

```bash
npm run env:start
npm run test:php
```

**Verify the tests catch the defect.** Revert `plugin.php` alone and re-run:

```bash
git checkout main -- plugin.php && npm run test:php
```

I did this before writing the fix. Both fail. The second failure states the
user-visible symptom directly:

```
get_the_title() returned a Style Guide entry.
- 'Editorial Style Guide'
+ 'Zebra'
```

After the fix: `OK (8 tests, 17 assertions)`.

Manual check, once ACF is present: put `[style-archive]` on a page with a
heading and some paragraphs below it, and confirm the content below still
renders the page's own data.

## Notes for the reviewer

- The reset is placed immediately before the `return` rather than right after
  `endif;`. Equivalent — nothing between them touches post data — and it keeps
  the diff to the two lines the defect is actually about.
- Two tests rather than one on purpose: the first asserts the mechanism (global
  `$post` restored), the second asserts the consequence (`get_the_title()`).
  The second is what makes a future regression legible to whoever hits it.

## Breaking changes

None. Content after `[style-archive]` starts rendering correctly; anything that
was inadvertently relying on the leaked `$post` was already displaying the
wrong post.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
