### PR TITLE
fix: remove the broken search_template override

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -161,23 +161,6 @@ function ucscgiving_create_style_guide_search_variation( $variations, $block_typ
 
 add_filter( 'get_block_type_variations', 'ucscgiving_create_style_guide_search_variation', 10, 2 );
 
-/**
- * Return Fund search results in Fund archive template
- * description: Returns the Fund search results in its archive template.
- *
- * @param string $template
- * @return string
- */
-function ucscgiving_style_guide_search_template( $template ) {
-	if ( is_search() && 'a_z_style_guide' === get_query_var( 'post_type' ) ) {
-		return locate_template( '' ); // this will return search results in the archive template.
-	}
-
-	return $template;
-}
-
-add_action( 'search_template', 'ucscgiving_style_guide_search_template' );
-
 function custom_filter_posts( $query ) {
     if ( ! is_admin() && $query->is_main_query() && is_search() && 'a_z_style_guide' === get_query_var( 'post_type' ) ) {
         // Only proceed if there's a search term

--- a/tests/SearchTemplateTest.php
+++ b/tests/SearchTemplateTest.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * BB-03 — the plugin must not hijack search template resolution.
+ *
+ * @package Blackbird_Sandbox
+ */
+
+/**
+ * Guards the removal of the dead search_template override.
+ */
+class SearchTemplateTest extends Blackbird_TestCase {
+
+	/**
+	 * The override is gone, not merely re-registered on the right hook.
+	 *
+	 * It was hooked with add_action on a filter, so its return value was
+	 * discarded and it never had any effect. Registering it correctly would
+	 * have made things worse, not better — see the next test.
+	 */
+	public function test_plugin_does_not_override_search_template() {
+		$this->assertFalse(
+			function_exists( 'ucscgiving_style_guide_search_template' ),
+			'The dead search_template callback still exists.'
+		);
+		$this->assertFalse(
+			has_filter( 'search_template', 'ucscgiving_style_guide_search_template' ),
+			'The callback is still registered on search_template.'
+		);
+		$this->assertFalse(
+			has_action( 'search_template', 'ucscgiving_style_guide_search_template' ),
+			'The callback is still registered as an action on search_template.'
+		);
+	}
+
+	/**
+	 * The plugin leaves search template resolution alone.
+	 *
+	 * Asserted by passing a sentinel through the filter rather than by calling
+	 * get_search_template(). The test environment pins WP_DEFAULT_THEME to the
+	 * 'default' stub, which ships no templates, so real resolution is empty
+	 * here whatever the plugin does. Passing a sentinel through measures only
+	 * the plugin's own contribution.
+	 *
+	 * Red against the previous code: the callback matched this query and
+	 * returned locate_template( '' ), which is an empty string.
+	 */
+	public function test_plugin_does_not_alter_the_search_template() {
+		self::factory()->post->create(
+			array(
+				'post_type'   => self::POST_TYPE,
+				'post_title'  => 'Serial comma',
+				'post_status' => 'publish',
+			)
+		);
+
+		$this->go_to( home_url( '/?s=comma&post_type=' . self::POST_TYPE ) );
+
+		$this->assertTrue( is_search(), 'Test setup failed: not a search query.' );
+		$this->assertSame(
+			self::POST_TYPE,
+			get_query_var( 'post_type' ),
+			'Test setup failed: the query is not scoped to the Style Guide post type.'
+		);
+
+		$sentinel = '/theme/search.php';
+
+		$this->assertSame(
+			$sentinel,
+			apply_filters( 'search_template', $sentinel ),
+			'Something in the plugin is still rewriting the search template.'
+		);
+	}
+}


### PR DESCRIPTION
Closes #8.

> **Stacked on #22 → #21.** Merge those first; this base retargets automatically.

## ⚠️ The finding was misdiagnosed — this is live, not inert

The roadmap and #8 both say the callback's return value is discarded because it
was registered with `add_action`, so "the template override never takes
effect." **That is wrong**, and I only found out because a test I expected to
pass went red.

`add_action()` is a direct alias of `add_filter()`:

```php
function add_action( $hook_name, $callback, $priority = 10, $accepted_args = 1 ) {
	return add_filter( $hook_name, $callback, $priority, $accepted_args );
}
```

`search_template` is fired with `apply_filters()`, so the return value **is**
honoured. The override has been active this whole time, returning
`locate_template( '' )` — an empty string. Style Guide searches have been
losing their search template and falling through to the index fallback.

So this is a real user-facing bug being fixed, not dead code being tidied.
I described it as behaviour-preserving when we discussed the options; it isn't.

## What changed

- `plugin.php` — deleted `ucscgiving_style_guide_search_template()` and its
  registration. 17 lines.
- `tests/SearchTemplateTest.php` — 2 tests.

## Why deletion rather than repair

Verified in the container:

| Expression | Result |
|---|---|
| `locate_template( '' )` | `''` |
| `locate_template( ['archive-a_z_style_guide.php','archive.php'] )` | `''` |
| `wp_is_block_theme()` | `true` |

Even a correctly formed `locate_template()` call resolves to nothing, because
the theme is a block theme and has no PHP archive templates. There is no
version of this callback that does something useful without a decision about
which *block* template should serve Style Guide search results — and that is
well outside a Phase 1 S1 fix. The `styleguide-search` block variation already
scopes these searches.

## How to test

```bash
npm run env:start
npm run test:php
```

**Verify the tests catch the defect:**

```bash
git checkout main -- plugin.php && npm run test:php
```

Both fail. After the fix: `OK (10 tests, 23 assertions)`.

## Notes for the reviewer

- **One of my tests was initially wrong and the suite caught it.** I first
  asserted on `get_search_template()` returning a non-empty path. That failed
  *with the plugin code already removed* — wp-env pins `WP_DEFAULT_THEME` to the
  `default` stub, which ships no templates, so resolution is empty regardless of
  the plugin. It was measuring the theme, not the plugin. Rewritten to pass a
  sentinel through `apply_filters( 'search_template', … )`, which isolates the
  plugin's own contribution and is theme-independent.
- **ROADMAP.md still carries the wrong diagnosis for BB-03.** Not touched here
  to keep this PR to one logical change; worth a follow-up so the next reader
  isn't misled.

## Breaking changes

Style Guide search result pages will now resolve through the normal search
template instead of the index fallback. That is the fix, but it is a visible
change on any site where those pages are in use — worth a look before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
