### PR TITLE
fix: Phase 2 plugin hygiene

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -8,7 +8,7 @@
  * Author:            @Herm71
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
- * Text Domain:       birdblocks
+ * Text Domain:       blackbird-playground
  *
  * @package           create-block
  */
@@ -154,15 +154,15 @@ function ucscgiving_create_style_guide_search_variation( $variations, $block_typ
 
 		$variations[] = array(
 			'name'        => 'styleguide-search',
-			'title'       => __( 'Style Guide Search', 'ucscgiving' ),
-			'description' => __( 'Search only Style Guide posts', 'ucscgiving' ),
+			'title'       => __( 'Style Guide Search', 'blackbird-playground' ),
+			'description' => __( 'Search only Style Guide posts', 'blackbird-playground' ),
 			'attributes'  => array(
 				'query'       => array(
 					'post_type' => 'a_z_style_guide',
 				),
-				'placeholder' => __( 'Search Style Guide', 'ucscgiving' ),
-				'buttonText'  => __( 'Search Style Guide', 'ucscgiving' ),
-				'label'       => __( 'Search Style Guide', 'ucscgiving' ),
+				'placeholder' => __( 'Search Style Guide', 'blackbird-playground' ),
+				'buttonText'  => __( 'Search Style Guide', 'blackbird-playground' ),
+				'label'       => __( 'Search Style Guide', 'blackbird-playground' ),
 			),
 		);
 

--- a/plugin.php
+++ b/plugin.php
@@ -16,6 +16,7 @@
 defined( 'ABSPATH' ) || exit;
 
 // Set plugin directory and base name.
+define( 'BLACKBIRD_PLUGIN_VERSION', '0.1.0' ); // Keep in step with the Version header above.
 define( 'UCSCCOMMS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) ); // Path to plugin directory.
 define( 'UCSCCOMMS_PLUGIN_BASE', plugin_basename( __FILE__ ) ); // Plugin base name 'plugin.php' at root.
 /**
@@ -25,12 +26,19 @@ function blackbird_playground_enqueue_styles() {
     // Get the plugin directory URL
     $plugin_url = plugin_dir_url(__FILE__);
 
+    $stylesheet_path = plugin_dir_path( __FILE__ ) . 'style.css';
+
+    // Version on file modification time so the browser picks up rebuilds. Fall
+    // back to the plugin version when the file is absent from a build, rather
+    // than passing filemtime()'s false through as a version.
+    $version = file_exists( $stylesheet_path ) ? filemtime( $stylesheet_path ) : BLACKBIRD_PLUGIN_VERSION;
+
     // Enqueue the compiled CSS file
     wp_enqueue_style(
         'blackbird-playground-style', // Handle
         $plugin_url . 'style.css', // Path to the compiled CSS file
         array(), // Dependencies
-        filemtime(plugin_dir_path(__FILE__) . 'style.css') // Version based on file modification time
+        $version
     );
 }
 add_action('wp_enqueue_scripts', 'blackbird_playground_enqueue_styles');

--- a/plugin.php
+++ b/plugin.php
@@ -15,14 +15,17 @@
 
 defined( 'ABSPATH' ) || exit;
 
-// Set plugin directory and base name.
-define( 'BLACKBIRD_PLUGIN_VERSION', '0.1.0' ); // Keep in step with the Version header above.
-define( 'UCSCCOMMS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) ); // Path to plugin directory.
-define( 'UCSCCOMMS_PLUGIN_BASE', plugin_basename( __FILE__ ) ); // Plugin base name 'plugin.php' at root.
+if ( ! defined( 'BLACKBIRD_PLUGIN_VERSION' ) ) {
+	define( 'BLACKBIRD_PLUGIN_VERSION', '0.1.0' ); // Keep in step with the Version header above.
+}
+
+if ( ! defined( 'BLACKBIRD_PLUGIN_DIR' ) ) {
+	define( 'BLACKBIRD_PLUGIN_DIR', plugin_dir_path( __FILE__ ) ); // Path to plugin directory.
+}
 /**
  * Enqueue the Blackbird Playground stylesheet.
  */
-function blackbird_playground_enqueue_styles() {
+function blackbird_enqueue_styles() {
     // Get the plugin directory URL
     $plugin_url = plugin_dir_url(__FILE__);
 
@@ -41,36 +44,36 @@ function blackbird_playground_enqueue_styles() {
         $version
     );
 }
-add_action('wp_enqueue_scripts', 'blackbird_playground_enqueue_styles');
+add_action('wp_enqueue_scripts', 'blackbird_enqueue_styles');
 
 /**
  * ACF JSON Save Point
  *
  * @param [type] $path
  * @return $path
- * @package ucsc-giving-functionality
+ * @package Blackbird_Sandbox
  */
-function ucsccomms_acf_json_save_point( $path ) {
-	$path = UCSCCOMMS_PLUGIN_DIR . 'acf-json';
+function blackbird_acf_json_save_point( $path ) {
+	$path = BLACKBIRD_PLUGIN_DIR . 'acf-json';
 	return $path;
 }
 // Set plugin directory for saving ACF JSON files.
-add_filter( 'acf/settings/save_json', 'ucsccomms_acf_json_save_point' );
+add_filter( 'acf/settings/save_json', 'blackbird_acf_json_save_point' );
 
 /**
  * ACF JSON Load Point
  *
  * @param [type] $paths
  * @return $paths
- * @package ucsc-giving-functionality
+ * @package Blackbird_Sandbox
  */
-function ucsccomms_acf_json_load_point( $paths ) {
+function blackbird_acf_json_load_point( $paths ) {
 	unset( $paths[0] );
-	$paths[] = UCSCCOMMS_PLUGIN_DIR . 'acf-json';
+	$paths[] = BLACKBIRD_PLUGIN_DIR . 'acf-json';
 	return $paths;
 }
 // Set plugin directory for loading ACF JSON files.
-add_filter( 'acf/settings/load_json', 'ucsccomms_acf_json_load_point' );
+add_filter( 'acf/settings/load_json', 'blackbird_acf_json_load_point' );
 
 /**
  * Register the A-Z Editorial Style Guide shortcode.
@@ -79,9 +82,9 @@ add_filter( 'acf/settings/load_json', 'ucsccomms_acf_json_load_point' );
  */
 // This shortcode outputs the A-Z Editorial Style Guide definitions.
 
-add_shortcode( 'style-definition','bb_a_z_style_guide_single_loop' );
+add_shortcode( 'style-definition','blackbird_style_guide_single_loop' );
 
-function bb_a_z_style_guide_single_loop(){
+function blackbird_style_guide_single_loop(){
 
 	$finaldefs = '';
 
@@ -102,9 +105,9 @@ return $finaldefs;
  */
 // This shortcode outputs the A-Z Editorial Style Guide archive loop.
 // It retrieves all posts of the 'a_z_style_guide' post type, ordered by title in ascending order, and displays each post's title along with its style definitions.
-add_shortcode( 'style-archive','bb_a_z_styles_archive_loop' );
+add_shortcode( 'style-archive','blackbird_style_guide_archive_loop' );
 
-function bb_a_z_styles_archive_loop() {
+function blackbird_style_guide_archive_loop() {
 	$finalloop = '';
 
 	// Call Post
@@ -147,7 +150,7 @@ function bb_a_z_styles_archive_loop() {
  * @param WP_Block_Type $block_type The block type being filtered.
  * @return mixed
  */
-function ucscgiving_create_style_guide_search_variation( $variations, $block_type ) {
+function blackbird_create_style_guide_search_variation( $variations, $block_type ) {
 	if ( 'core/search' !== $block_type->name ) {
 			return $variations;
 	}
@@ -169,9 +172,9 @@ function ucscgiving_create_style_guide_search_variation( $variations, $block_typ
 		return $variations;
 }
 
-add_filter( 'get_block_type_variations', 'ucscgiving_create_style_guide_search_variation', 10, 2 );
+add_filter( 'get_block_type_variations', 'blackbird_create_style_guide_search_variation', 10, 2 );
 
-function custom_filter_posts( $query ) {
+function blackbird_filter_style_guide_search( $query ) {
     if ( ! is_admin() && $query->is_main_query() && is_search() && 'a_z_style_guide' === get_query_var( 'post_type' ) ) {
         // Only proceed if there's a search term
         if ( ! empty( $query->query_vars['s'] ) ) {
@@ -213,4 +216,4 @@ function custom_filter_posts( $query ) {
         }
     }
 }
-add_action( 'pre_get_posts', 'custom_filter_posts' );
+add_action( 'pre_get_posts', 'blackbird_filter_style_guide_search' );

--- a/plugin.php
+++ b/plugin.php
@@ -13,6 +13,8 @@
  * @package           create-block
  */
 
+defined( 'ABSPATH' ) || exit;
+
 // Set plugin directory and base name.
 define( 'UCSCCOMMS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) ); // Path to plugin directory.
 define( 'UCSCCOMMS_PLUGIN_BASE', plugin_basename( __FILE__ ) ); // Plugin base name 'plugin.php' at root.

--- a/src/block.json
+++ b/src/block.json
@@ -17,7 +17,7 @@
 	"supports": {
 		"html": false
 	},
-	"textdomain": "birdblocks",
+	"textdomain": "blackbird-playground",
 	"editorScript": "file:./index.js",
 	"editorStyle": "file:./index.css",
 	"style": "file:./style-index.css"

--- a/tests/DirectAccessTest.php
+++ b/tests/DirectAccessTest.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * BB-07 — plugin.php must not execute on a direct HTTP request.
+ *
+ * @package Blackbird_Sandbox
+ */
+
+/**
+ * ABSPATH guard regression.
+ */
+class DirectAccessTest extends WP_UnitTestCase {
+
+	/**
+	 * Running the file outside WordPress must exit quietly.
+	 *
+	 * Executed in a separate PHP process with no WordPress loaded, which is
+	 * what a direct web request to the file amounts to. Without the guard the
+	 * first WordPress call in the file raises a fatal.
+	 */
+	public function test_plugin_file_exits_without_wordpress() {
+		$plugin = dirname( __DIR__ ) . '/plugin.php';
+		$output = array();
+		$status = 0;
+
+		exec( 'php ' . escapeshellarg( $plugin ) . ' 2>&1', $output, $status );
+
+		$joined = implode( "\n", $output );
+
+		$this->assertSame( 0, $status, "Direct execution did not exit cleanly:\n" . $joined );
+		$this->assertSame( '', trim( $joined ), "Direct execution produced output:\n" . $joined );
+	}
+}

--- a/tests/NamingTest.php
+++ b/tests/NamingTest.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * BB-08, BB-09, BB-10 — one prefix, no inherited names, no unguarded defines.
+ *
+ * @package Blackbird_Sandbox
+ */
+
+/**
+ * Naming and constant-guard regressions.
+ */
+class NamingTest extends WP_UnitTestCase {
+
+	/**
+	 * Names inherited from unrelated plugins, all of which must be gone.
+	 *
+	 * @return array[]
+	 */
+	public function inherited_function_names() {
+		return array(
+			'ucsccomms ACF save point' => array( 'ucsccomms_acf_json_save_point' ),
+			'ucsccomms ACF load point' => array( 'ucsccomms_acf_json_load_point' ),
+			'ucscgiving variation'     => array( 'ucscgiving_create_style_guide_search_variation' ),
+			'bb_ single loop'          => array( 'bb_a_z_style_guide_single_loop' ),
+			'bb_ archive loop'         => array( 'bb_a_z_styles_archive_loop' ),
+			'unprefixed query filter'  => array( 'custom_filter_posts' ),
+			'old enqueue name'         => array( 'blackbird_playground_enqueue_styles' ),
+		);
+	}
+
+	/**
+	 * @dataProvider inherited_function_names
+	 *
+	 * @param string $name Function name that must no longer exist.
+	 */
+	public function test_inherited_function_names_are_gone( $name ) {
+		$this->assertFalse( function_exists( $name ), "$name still exists." );
+	}
+
+	/**
+	 * The replacements exist and are prefixed consistently.
+	 *
+	 * @return array[]
+	 */
+	public function replacement_function_names() {
+		return array(
+			array( 'blackbird_enqueue_styles' ),
+			array( 'blackbird_acf_json_save_point' ),
+			array( 'blackbird_acf_json_load_point' ),
+			array( 'blackbird_style_guide_single_loop' ),
+			array( 'blackbird_style_guide_archive_loop' ),
+			array( 'blackbird_create_style_guide_search_variation' ),
+			array( 'blackbird_filter_style_guide_search' ),
+		);
+	}
+
+	/**
+	 * @dataProvider replacement_function_names
+	 *
+	 * @param string $name Function name that must exist.
+	 */
+	public function test_replacement_functions_exist( $name ) {
+		$this->assertTrue( function_exists( $name ), "$name is missing." );
+		$this->assertStringStartsWith( 'blackbird_', $name );
+	}
+
+	/**
+	 * Renaming must not silently unhook anything.
+	 */
+	public function test_replacements_are_still_hooked() {
+		$this->assertNotFalse( has_action( 'wp_enqueue_scripts', 'blackbird_enqueue_styles' ) );
+		$this->assertNotFalse( has_filter( 'acf/settings/save_json', 'blackbird_acf_json_save_point' ) );
+		$this->assertNotFalse( has_filter( 'acf/settings/load_json', 'blackbird_acf_json_load_point' ) );
+		$this->assertNotFalse( has_filter( 'get_block_type_variations', 'blackbird_create_style_guide_search_variation' ) );
+		$this->assertNotFalse( has_action( 'pre_get_posts', 'blackbird_filter_style_guide_search' ) );
+	}
+
+	/**
+	 * The shortcode tags are a public contract and must survive the renames.
+	 *
+	 * They appear in saved post content; renaming a callback is free, renaming
+	 * a tag breaks every page already using it.
+	 */
+	public function test_shortcode_tags_are_unchanged() {
+		$this->assertTrue( shortcode_exists( 'style-definition' ) );
+		$this->assertTrue( shortcode_exists( 'style-archive' ) );
+	}
+
+	/**
+	 * Constants are renamed, guarded, and the unused one is gone.
+	 */
+	public function test_constants() {
+		$this->assertTrue( defined( 'BLACKBIRD_PLUGIN_DIR' ), 'BLACKBIRD_PLUGIN_DIR is not defined.' );
+		$this->assertFalse( defined( 'UCSCCOMMS_PLUGIN_DIR' ), 'UCSCCOMMS_PLUGIN_DIR still exists.' );
+		$this->assertFalse( defined( 'UCSCCOMMS_PLUGIN_BASE' ), 'UCSCCOMMS_PLUGIN_BASE still exists.' );
+		$this->assertSame( trailingslashit( dirname( __DIR__ ) ), BLACKBIRD_PLUGIN_DIR );
+	}
+
+	/**
+	 * Every define() is paired with a guard for that same constant.
+	 *
+	 * A source-level assertion rather than a behavioural one. The redefinition
+	 * notice it protects against only fires when another plugin defines the
+	 * same name first, which cannot be staged from inside a suite that has
+	 * already loaded plugin.php once.
+	 */
+	public function test_defines_are_guarded() {
+		$source = file_get_contents( dirname( __DIR__ ) . '/plugin.php' );
+
+		preg_match_all( "/define\\(\\s*'([A-Z0-9_]+)'/", $source, $defined );
+
+		$this->assertNotEmpty( $defined[1], 'No define() calls found; this test is not checking anything.' );
+
+		foreach ( $defined[1] as $constant ) {
+			$this->assertMatchesRegularExpression(
+				"/if\\s*\\(\\s*!\\s*defined\\(\\s*'" . preg_quote( $constant, '/' ) . "'\\s*\\)\\s*\\)/",
+				$source,
+				"define( '$constant' ) is not wrapped in a defined() guard."
+			);
+		}
+	}
+
+	/**
+	 * The ACF JSON paths still resolve after the constant rename.
+	 */
+	public function test_acf_json_paths_still_resolve() {
+		$expected = BLACKBIRD_PLUGIN_DIR . 'acf-json';
+
+		$this->assertSame( $expected, blackbird_acf_json_save_point( '/somewhere/else' ) );
+		$this->assertContains( $expected, blackbird_acf_json_load_point( array( '/default/path' ) ) );
+	}
+}

--- a/tests/StylesheetEnqueueTest.php
+++ b/tests/StylesheetEnqueueTest.php
@@ -52,7 +52,7 @@ class StylesheetEnqueueTest extends WP_UnitTestCase {
 	 * The normal case still gets a cache-busting version.
 	 */
 	public function test_enqueues_with_a_version_when_stylesheet_exists() {
-		blackbird_playground_enqueue_styles();
+		blackbird_enqueue_styles();
 
 		$registered = wp_styles()->registered;
 
@@ -69,7 +69,7 @@ class StylesheetEnqueueTest extends WP_UnitTestCase {
 	public function test_missing_stylesheet_does_not_warn_or_set_false_version() {
 		$this->assertTrue( rename( $this->stylesheet, $this->stashed ), 'Could not stash style.css.' );
 
-		blackbird_playground_enqueue_styles();
+		blackbird_enqueue_styles();
 
 		$registered = wp_styles()->registered;
 

--- a/tests/StylesheetEnqueueTest.php
+++ b/tests/StylesheetEnqueueTest.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * BB-06 — the stylesheet version must not depend on filemtime() succeeding.
+ *
+ * @package Blackbird_Sandbox
+ */
+
+/**
+ * Enqueue guard regression.
+ */
+class StylesheetEnqueueTest extends WP_UnitTestCase {
+
+	/**
+	 * Handle the plugin registers.
+	 */
+	const HANDLE = 'blackbird-playground-style';
+
+	/**
+	 * Path to the stylesheet the plugin versions against.
+	 *
+	 * @var string
+	 */
+	private $stylesheet;
+
+	/**
+	 * Path the stylesheet is moved to while simulating its absence.
+	 *
+	 * @var string
+	 */
+	private $stashed;
+
+	/**
+	 * Resolve paths.
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->stylesheet = dirname( __DIR__ ) . '/style.css';
+		$this->stashed    = $this->stylesheet . '.phpunit-stashed';
+	}
+
+	/**
+	 * Always put the stylesheet back, even if an assertion fails.
+	 */
+	public function tear_down() {
+		if ( file_exists( $this->stashed ) ) {
+			rename( $this->stashed, $this->stylesheet );
+		}
+		parent::tear_down();
+	}
+
+	/**
+	 * The normal case still gets a cache-busting version.
+	 */
+	public function test_enqueues_with_a_version_when_stylesheet_exists() {
+		blackbird_playground_enqueue_styles();
+
+		$registered = wp_styles()->registered;
+
+		$this->assertArrayHasKey( self::HANDLE, $registered, 'Stylesheet was not registered.' );
+		$this->assertNotEmpty( $registered[ self::HANDLE ]->ver, 'No cache-busting version was set.' );
+	}
+
+	/**
+	 * A missing stylesheet must not raise a warning or set a false version.
+	 *
+	 * phpunit.xml.dist sets failOnWarning, so an unguarded filemtime() on a
+	 * missing file fails this test on the warning alone.
+	 */
+	public function test_missing_stylesheet_does_not_warn_or_set_false_version() {
+		$this->assertTrue( rename( $this->stylesheet, $this->stashed ), 'Could not stash style.css.' );
+
+		blackbird_playground_enqueue_styles();
+
+		$registered = wp_styles()->registered;
+
+		$this->assertArrayHasKey( self::HANDLE, $registered, 'Stylesheet was not registered.' );
+		$this->assertNotFalse(
+			$registered[ self::HANDLE ]->ver,
+			'Version is false; filemtime() failed and its return value was used anyway.'
+		);
+	}
+}

--- a/tests/TextDomainTest.php
+++ b/tests/TextDomainTest.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * BB-05 — every translatable string must use the plugin's declared domain.
+ *
+ * @package Blackbird_Sandbox
+ */
+
+/**
+ * Text domain regression.
+ */
+class TextDomainTest extends WP_UnitTestCase {
+
+	/**
+	 * The domain the plugin declares, matching the directory slug so that
+	 * WordPress can auto-load translations without load_plugin_textdomain().
+	 */
+	const DOMAIN = 'blackbird-playground';
+
+	/**
+	 * The header declares the expected domain.
+	 */
+	public function test_header_declares_the_domain() {
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+
+		$data = get_plugin_data( dirname( __DIR__ ) . '/plugin.php', false, false );
+
+		$this->assertSame( self::DOMAIN, $data['TextDomain'], 'Plugin header declares a different text domain.' );
+	}
+
+	/**
+	 * The domain matches the plugin directory.
+	 *
+	 * WordPress only auto-loads translations when these agree.
+	 */
+	public function test_domain_matches_the_plugin_directory() {
+		$this->assertSame(
+			self::DOMAIN,
+			basename( dirname( __DIR__ ) ),
+			'Text domain no longer matches the plugin directory name.'
+		);
+	}
+
+	/**
+	 * The block variation's strings actually resolve under that domain.
+	 *
+	 * Intercepts gettext for this domain only and marks anything passing
+	 * through it, then triggers the variation filter. A string still declared
+	 * against the old domain is never offered to this filter and comes back
+	 * unmarked.
+	 */
+	public function test_block_variation_strings_use_the_domain() {
+		$marker = '@@translated@@';
+
+		$intercept = static function ( $translation, $text, $domain ) use ( $marker ) {
+			return self::DOMAIN === $domain ? $marker . $text : $translation;
+		};
+
+		add_filter( 'gettext', $intercept, 10, 3 );
+
+		$block_type       = new stdClass();
+		$block_type->name = 'core/search';
+		$variations       = apply_filters( 'get_block_type_variations', array(), $block_type );
+
+		remove_filter( 'gettext', $intercept, 10 );
+
+		$this->assertNotEmpty( $variations, 'The search block variation was not registered.' );
+
+		$variation = $variations[0];
+
+		$this->assertStringStartsWith( $marker, $variation['title'], 'Variation title does not use the plugin text domain.' );
+		$this->assertStringStartsWith( $marker, $variation['description'], 'Variation description does not use the plugin text domain.' );
+		$this->assertStringStartsWith( $marker, $variation['attributes']['placeholder'], 'Placeholder does not use the plugin text domain.' );
+		$this->assertStringStartsWith( $marker, $variation['attributes']['buttonText'], 'Button text does not use the plugin text domain.' );
+		$this->assertStringStartsWith( $marker, $variation['attributes']['label'], 'Label does not use the plugin text domain.' );
+	}
+}


### PR DESCRIPTION
Closes #10
Closes #11
Closes #12
Closes #13
Closes #14
Closes #15

All six Phase 2 issues in one PR, as requested. Eight atomic commits, each fix
paired with a test that was confirmed red first.

## What changed

| Issue | Change |
|---|---|
| #12 BB-07 | `defined( 'ABSPATH' ) \|\| exit;` at the top of `plugin.php` |
| #11 BB-06 | `file_exists()` guard on `filemtime()`, falling back to a new `BLACKBIRD_PLUGIN_VERSION` |
| #10 BB-05 | One text domain, `blackbird-playground`, across header, all 5 `__()` calls, and `block.json` |
| #13 BB-08 | `UCSCCOMMS_PLUGIN_DIR` → `BLACKBIRD_PLUGIN_DIR`, both defines guarded, unused `UCSCCOMMS_PLUGIN_BASE` deleted |
| #14 BB-09 | `custom_filter_posts()` → `blackbird_filter_style_guide_search()` |
| #15 BB-10 | All seven functions on the `blackbird_` prefix |

Suite: **35 tests, 75 assertions**, up from 10.

## Decisions worth reviewing

**Text domain is `blackbird-playground`, not either incumbent value.** The
header said `birdblocks`, the calls said `ucscgiving`. WordPress only auto-loads
a plugin's translations when the domain matches the directory slug, and there is
no `load_plugin_textdomain()` call and no `languages/` directory — so both
existing values would have stayed inert even once made consistent.

**Shortcode tags are untouched.** `style-definition` and `style-archive` are
stored in post content; renaming a callback is free, renaming a tag breaks every
page already using it. There is a test pinning this.

**`UCSCCOMMS_PLUGIN_BASE` is deleted, not renamed.** Nothing read it.

**No deprecation shims.** Per your call. Nothing in this repo referenced the old
names outside `plugin.php`; I could not grep the wider site from this checkout,
which the roadmap asks for.

## ⚠️ PHPCS gets *worse*, and that is correct

`plugin.php` goes from **178 to 183 errors**. The entire +5 is
`WordPress.NamingConventions.PrefixAllGlobals`, which rose from 4 to 9.

`.phpcs.xml.dist` declares the expected prefix as `ucsc` and the expected text
domain as `ucsc-2022` — both inherited from an unrelated project. Renaming
*away* from `ucsc*` scores worse against a ruleset that still expects it. The
code is more correct; the linter is misconfigured.

This is #16, which owns re-scoping the ruleset, and I left it alone to keep this
PR inside Phase 2. Worth doing soon, since the ruleset now actively penalises
correct naming.

## How to test

```bash
npm run env:start
npm run test:php     # OK (35 tests, 75 assertions)
```

Direct-access guard, without WordPress loaded:

```bash
php plugin.php ; echo "exit=$?"   # exit=0, no output
```

**Verify the tests catch the defects** — revert `plugin.php` and re-run:

```bash
git checkout main -- plugin.php && npm run test:php
```

## Notes for the reviewer

- **One of my tests was wrong and I caught it before committing.** The
  guarded-defines check used `/^\s*define\(/m`, which matches *every* `define()`
  including correctly guarded ones, so it failed against code that was already
  right. Rewritten to pair each `define()` with a `defined()` guard for that
  same constant, then verified by removing a guard and confirming it goes red.
- **That test is source-level, not behavioural**, and says so in its docblock.
  The redefinition notice only fires when another plugin defines the name first,
  which cannot be staged inside a suite that has already loaded `plugin.php`.
- **The rename broke my own BB-06 test**, which still called
  `blackbird_playground_enqueue_styles()`. Fixed in the rename commit — the
  suite doing its job.
- **The BB-06 test moves `style.css` on disk** to simulate its absence, and
  restores it in `tear_down` so a failing assertion cannot leave a broken tree.
- `build/block.json` carries the domain change but is gitignored; rebuild to
  regenerate.

## Breaking changes

**Anything outside this repo calling the old names will fatal or silently stop
firing.** Removed: `UCSCCOMMS_PLUGIN_DIR`, `UCSCCOMMS_PLUGIN_BASE`,
`custom_filter_posts()`, `ucsccomms_acf_json_*()`,
`ucscgiving_create_style_guide_search_variation()`, `bb_a_z_*()`,
`blackbird_playground_enqueue_styles()`. Please confirm nothing in the wider
site references these before merging.

Shortcodes, hooks, and rendered output are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
